### PR TITLE
adds huff talk.

### DIFF
--- a/content/syllabus.md
+++ b/content/syllabus.md
@@ -111,6 +111,8 @@ The first half of the day will follow the R Novice Gapminder lesson http://swcar
 
 ### Day 3: Databases and Visualization
 
+['Best Practices in Scientific Computing'](http://katyhuff.github.io/2017-05-31-pi4) - Kathryn Huff
+
 Wednesday May 31 
 
 1. Data structures


### PR DESCRIPTION
The link is a 404 right now, but the slides for the talk will appear there eventually. 